### PR TITLE
Updated nexus APIs to manipulate proxy and group repos

### DIFF
--- a/src/devsecops/cli/services/nexus.py
+++ b/src/devsecops/cli/services/nexus.py
@@ -157,7 +157,7 @@ def dso_nexus_update_group_repo(url, login_username, login_password, verbose,
     with nexus.Nexus(
         url, login_username, login_password, verbosity=verbose
     ) as api:
-        if not api.search_repos(group_repository_name):
+        if api.search_repos(group_repository_name):
             try:
                 if api.update_group_repo(group_repository_name, member_repository_names.split(',')) is not None:
                     print(f'group repo {group_repository_name} added')
@@ -169,7 +169,7 @@ def dso_nexus_update_group_repo(url, login_username, login_password, verbose,
                 errors[group_repository] = e.msg
                 print(f'group repo {group_repository_name} failed')
         else:
-            print(f'group repo {group_repository_name} ok')
+            print(f'group repo {group_repository_name} doesn\'t exist')
     for repo, error in errors.items():
         sys.stderr.write(f'Error updating group repo {repo}:\n{error}\n')
     sys.stderr.flush

--- a/src/devsecops/cli/services/nexus.py
+++ b/src/devsecops/cli/services/nexus.py
@@ -149,7 +149,7 @@ def dso_nexus_add_proxy_repo(url, login_username, login_password, verbose,
 @click.option('--member-repository-names', '-r', required=True,
               help=('the name of the repositories to group '
                     '(separate multiples with commas)'))
-def dso_nexus_add_repo(url, login_username, login_password, verbose,
+def dso_nexus_update_group_repo(url, login_username, login_password, verbose,
                        group_repository, member_repository_names):
     """Update group repo with the list of member repositories"""
     exit_code = 0

--- a/src/devsecops/cli/services/nexus.py
+++ b/src/devsecops/cli/services/nexus.py
@@ -109,3 +109,68 @@ def dso_nexus_add_repo(url, login_username, login_password, verbose,
         sys.stderr.write(f'Error adding {repo}:\n{error}\n')
     sys.stderr.flush
     exit(exit_code)
+
+@dso_nexus.command(name='add-proxy-repository')
+@opts.default_opts
+@click.option('--repository-name', '-r', required=True,
+              help=('the name of the repositories to add '))
+@click.option('--remote-repo-url', '-r', required=True,
+              help=('the URL of the remote repo to proxy'))
+def dso_nexus_add_proxy_repo(url, login_username, login_password, verbose,
+                       repository_name, remote_repo_url):
+    """Add a Maven proxy repositories to the Nexus instance specified by URL"""
+    exit_code = 0
+    errors = {}
+    with nexus.Nexus(
+        url, login_username, login_password, verbosity=verbose
+    ) as api:
+        if not api.search_repos(repository_name):
+            try:
+                if api.add_proxy_repo(repository_name) is not None:
+                    print(f'proxy {repository_name} added')
+                else:
+                    exit_code += 1
+                    print(f'proxy {repository_name} failed')
+            except Exception as e:
+                exit_code += 1
+                errors[repository_name] = e.msg
+                print(f'proxy {repository_name} failed')
+        else:
+            print(f'proxy {repository_name} ok')
+    for repo, error in errors.items():
+        sys.stderr.write(f'Error adding {repo}:\n{error}\n')
+    sys.stderr.flush
+    exit(exit_code)    
+
+@dso_nexus.command(name='update-group-repo')
+@opts.default_opts
+@click.option('--group-repository-name', '-r', required=True,
+              help=('the name of the group repository to update '))
+@click.option('--member-repository-names', '-r', required=True,
+              help=('the name of the repositories to group '
+                    '(separate multiples with commas)'))
+def dso_nexus_add_repo(url, login_username, login_password, verbose,
+                       group_repository, member_repository_names):
+    """Update group repo with the list of member repositories"""
+    exit_code = 0
+    errors = {}
+    with nexus.Nexus(
+        url, login_username, login_password, verbosity=verbose
+    ) as api:
+        if not api.search_repos(group_repository):
+            try:
+                if api.update_group_repo(group_repository, member_repository_names.split(',')) is not None:
+                    print(f'group repo {group_repository} added')
+                else:
+                    exit_code += 1
+                    print(f'group repo {group_repository} failed')
+            except Exception as e:
+                exit_code += 1
+                errors[group_repository] = e.msg
+                print(f'group repo {group_repository} failed')
+        else:
+            print(f'group repo {group_repository} ok')
+    for repo, error in errors.items():
+        sys.stderr.write(f'Error updating group repo {repo}:\n{error}\n')
+    sys.stderr.flush
+    exit(exit_code)

--- a/src/devsecops/cli/services/nexus.py
+++ b/src/devsecops/cli/services/nexus.py
@@ -126,7 +126,7 @@ def dso_nexus_add_proxy_repo(url, login_username, login_password, verbose,
     ) as api:
         if not api.search_repos(repository_name):
             try:
-                if api.add_proxy_repo(repository_name) is not None:
+                if api.add_proxy_repo(repository_name, remote_repo_url) is not None:
                     print(f'proxy {repository_name} added')
                 else:
                     exit_code += 1

--- a/src/devsecops/cli/services/nexus.py
+++ b/src/devsecops/cli/services/nexus.py
@@ -150,26 +150,26 @@ def dso_nexus_add_proxy_repo(url, login_username, login_password, verbose,
               help=('the name of the repositories to group '
                     '(separate multiples with commas)'))
 def dso_nexus_update_group_repo(url, login_username, login_password, verbose,
-                       group_repository, member_repository_names):
+                       group_repository_name, member_repository_names):
     """Update group repo with the list of member repositories"""
     exit_code = 0
     errors = {}
     with nexus.Nexus(
         url, login_username, login_password, verbosity=verbose
     ) as api:
-        if not api.search_repos(group_repository):
+        if not api.search_repos(group_repository_name):
             try:
-                if api.update_group_repo(group_repository, member_repository_names.split(',')) is not None:
-                    print(f'group repo {group_repository} added')
+                if api.update_group_repo(group_repository_name, member_repository_names.split(',')) is not None:
+                    print(f'group repo {group_repository_name} added')
                 else:
                     exit_code += 1
-                    print(f'group repo {group_repository} failed')
+                    print(f'group repo {group_repository_name} failed')
             except Exception as e:
                 exit_code += 1
                 errors[group_repository] = e.msg
-                print(f'group repo {group_repository} failed')
+                print(f'group repo {group_repository_name} failed')
         else:
-            print(f'group repo {group_repository} ok')
+            print(f'group repo {group_repository_name} ok')
     for repo, error in errors.items():
         sys.stderr.write(f'Error updating group repo {repo}:\n{error}\n')
     sys.stderr.flush

--- a/src/devsecops/nexus/nexus.py
+++ b/src/devsecops/nexus/nexus.py
@@ -3,6 +3,7 @@
 
 from devsecops.base.base_handler import BaseApiHandler, UnexpectedApiResponse
 from typing import TypeVar
+from typing import List
 from base64 import b64encode
 import requests
 import json

--- a/src/devsecops/nexus/nexus.py
+++ b/src/devsecops/nexus/nexus.py
@@ -141,6 +141,10 @@ class Nexus(BaseApiHandler):
                 "enabled": True,
                 "timeToLive": 1440
             },
+            "httpClient": {
+                "blocked": False,
+                "autoBlock": True,
+            },
             'cleanup': None,
             'maven': {
                 'versionPolicy': 'RELEASE',

--- a/src/devsecops/nexus/nexus.py
+++ b/src/devsecops/nexus/nexus.py
@@ -117,6 +117,56 @@ class Nexus(BaseApiHandler):
         return self.api_req('post', 'beta/repositories/maven/hosted', data,
                             ok=[201])
 
+    def add_proxy_repo(self, reponame: str = None, remoterepourl: str = None) -> requests.Response:
+        """
+        Adds a Maven2 format proxy repository backed by the default blobstore
+        to the server.
+        """
+        data = {
+            'name': reponame,
+            'online': True,
+            'format': 'maven2',
+            'storage': {
+                'blobStoreName': 'default',
+                'strictContentTypeValidation': True,
+                'writePolicy': 'ALLOW_ONCE'
+            },
+            'proxy': {
+                'remoteUrl': remoterepourl,
+                'contentMaxAge': 1440
+            },
+            "negativeCache": {
+                "enabled": True,
+                "timeToLive": 1440
+            },
+            'cleanup': None,
+            'maven': {
+                'versionPolicy': 'RELEASE',
+                'layoutPolicy': 'STRICT'
+            }
+        }
+        return self.api_req('post', 'beta/repositories/maven/proxy', data,
+                            ok=[201])
+
+    def update_group_repo(self, reponame: str , memberreponames: List[str]) -> requests.Response:
+        """
+        Adds a new repository to the default set of repos in the maven-public group.
+        """
+        data = {
+            'name': reponame,
+            'online': True,
+            'format': 'maven2',
+            'storage': {
+                'blobStoreName': 'default',
+                'strictContentTypeValidation': True,
+            },
+            'group': {
+                "memberNames": memberreponames
+            }
+        }
+        return self.api_req('put', f'beta/repositories/maven/group/{reponame}', data,
+                            ok=[201])
+
     def search_repos(self, reponame: str = '') -> list:
         """
         Returns a list of all repositories whose name is similar to reponame

--- a/src/devsecops/nexus/nexus.py
+++ b/src/devsecops/nexus/nexus.py
@@ -171,7 +171,7 @@ class Nexus(BaseApiHandler):
             }
         }
         return self.api_req('put', f'beta/repositories/maven/group/{reponame}', data,
-                            ok=[201])
+                            ok=[204])
 
     def search_repos(self, reponame: str = '') -> list:
         """

--- a/src/devsecops/nexus/nexus.py
+++ b/src/devsecops/nexus/nexus.py
@@ -134,7 +134,8 @@ class Nexus(BaseApiHandler):
             },
             'proxy': {
                 'remoteUrl': remoterepourl,
-                'contentMaxAge': 1440
+                'contentMaxAge': 1440,
+                'metadataMaxAge': 1440,
             },
             "negativeCache": {
                 "enabled": True,


### PR DESCRIPTION
The workshop needed to be able to add a new proxy repo to Nexus and add that proxy repo to the group repository that proxies the maven builds